### PR TITLE
use cl-first instead of first to remove dependency on deprecated 'cl

### DIFF
--- a/chezmoi.el
+++ b/chezmoi.el
@@ -39,7 +39,7 @@
   (funcall f (completing-read prompt files)))
 
 (defun chezmoi|source-file (target-file)
-  (first (split-string (shell-command-to-string (concat "chezmoi source-path " target-file))
+  (cl-first (split-string (shell-command-to-string (concat "chezmoi source-path " target-file))
                        "\n")))
 
 (defun chezmoi|managed ()


### PR DESCRIPTION
I was unable to execute the `chezmoi|ediff` function in my emacs 28.0.50.

In newer versions of emacs (28.0.50) the `cl` lib does not seem to be loaded by default anymore. The `first` function is part of the deprecated `cl` lib and therefore is not found. This change swaps out the `first` function for `cl-first`, which is included in the already-imported `cl-lib`.