### PR TITLE
Update docstrings quotes to produce links in emacs help buffers

### DIFF
--- a/chezmoi.el
+++ b/chezmoi.el
@@ -29,8 +29,8 @@
 ;; Chezmoi is a dotfile management system that uses a source-target state
 ;; architecture. This package provides convenience functions for maintaining
 ;; synchronization between the source and target states when making changes to
-;; your dotfiles through Emacs. It provides alternatives to 'find-file' and
-;; 'save-buffer' for source state files which maintain synchronization to the
+;; your dotfiles through Emacs. It provides alternatives to `find-file' and
+;; `save-buffer' for source state files which maintain synchronization to the
 ;; target state. It also provides diff/ediff tools for resolving when dotfiles
 ;; get out of sync. Dired and magit integration is also provided.
 
@@ -152,7 +152,7 @@
 (defun chezmoi-write (&optional arg target-file)
   "Run =chezmoi apply= on the TARGET-FILE.
 This overwrites the target with the source state.
-With prefix ARG, use 'shell' to run command."
+With prefix ARG, use `shell' to run command."
   (interactive "P")
   (let* ((f (if target-file target-file (chezmoi-target-file (buffer-file-name))))
          (cmd (concat "chezmoi apply " (shell-quote-argument f))))
@@ -194,10 +194,10 @@ If ARG is non-nil, switch to the diff-buffer."
 
 (defun chezmoi-find ()
   "Edit a source file managed by chezmoi.
-If the target file has the same state as the source file,add a hook to
-'save-buffer' that applies the source state to the target state. This way, when
+If the target file has the same state as the source file, add a hook to
+`save-buffer' that applies the source state to the target state. This way, when
 the buffer editing the source state is saved the target state is kept in sync.
-Note: Does not run =chezmoi edit="
+Note: Does not run =chezmoi edit=."
   (interactive)
   (chezmoi--select-file (chezmoi-managed-files)
                         "Select a dotfile to edit: "
@@ -213,7 +213,7 @@ Note: Does not run =chezmoi edit="
                             (add-hook 'after-save-hook (lambda () (chezmoi-write nil)) 0 t)))))
 
 (defun chezmoi-ediff ()
-  "Choose a dotfile to merge with its source using ediff.
+  "Choose a dotfile to merge with its source using `ediff'.
 Note: Does not run =chezmoi merge=."
   (interactive)
   (chezmoi--select-file (chezmoi-changed-files)


### PR DESCRIPTION
Just some minor changes to some docstrings. Mostly changing quotes of elisp functions so that links are created in emacs help buffers. But also some other, even more minor changes.