### PR TITLE
Allow non-interactive use of chezmoi-file and chezmoi-ediff

### DIFF
--- a/chezmoi.el
+++ b/chezmoi.el
@@ -192,34 +192,36 @@ If ARG is non-nil, switch to the diff-buffer."
             (push (concat "~" file-name) files)))
         files))))
 
-(defun chezmoi-find ()
-  "Edit a source file managed by chezmoi.
+(defun chezmoi-find (file)
+  "Edit a source FILE managed by chezmoi.
 If the target file has the same state as the source file,add a hook to
 'save-buffer' that applies the source state to the target state. This way, when
 the buffer editing the source state is saved the target state is kept in sync.
 Note: Does not run =chezmoi edit="
-  (interactive)
-  (chezmoi--select-file (chezmoi-managed-files)
-                        "Select a dotfile to edit: "
-                        (lambda (file)
-                          (find-file (chezmoi-source-file file))
-                          (let ((mode (assoc-default
-                                       (file-name-nondirectory file)
-                                       auto-mode-alist
-                                       'string-match)))
-                            (when mode (funcall mode)))
-                          (message file)
-                          (unless (member file (chezmoi-changed-files))
-                            (add-hook 'after-save-hook (lambda () (chezmoi-write nil)) 0 t)))))
+  (interactive
+   (list (completing-read
+          "Select a dotfile to edit: "
+          (chezmoi-managed-files)
+          nil t)))
+  (find-file (chezmoi-source-file file))
+  (let ((mode (assoc-default
+               (file-name-nondirectory file)
+               auto-mode-alist
+               'string-match)))
+    (when mode (funcall mode)))
+  (message file)
+  (unless (member file (chezmoi-changed-files))
+    (add-hook 'after-save-hook (lambda () (chezmoi-write nil)) 0 t)))
 
-(defun chezmoi-ediff ()
-  "Choose a dotfile to merge with its source using ediff.
+(defun chezmoi-ediff (dotfile)
+  "Choose a DOTFILE to merge with its source using ediff.
 Note: Does not run =chezmoi merge=."
-  (interactive)
-  (chezmoi--select-file (chezmoi-changed-files)
-                        "Select a dotfile to merge: "
-                        (lambda (file)
-                          (ediff-files (chezmoi-source-file file) file))))
+  (interactive
+   (list (completing-read
+          "Select a dotfile to merge: "
+          (chezmoi-changed-files)
+          nil t)))
+   (ediff-files (chezmoi-source-file dotfile) dotfile))
 
 (defun chezmoi-magit-status ()
   "Show the status of the chezmoi source repository."


### PR DESCRIPTION
Update functions `chezmoi-find` and `chezmoi-ediff` to allow their use in noninteractive code.

The motivation was the ability to use `chezmoi-find` in:

```
  (org-link-set-parameters "dotfile"
                           :follow (lambda (fn)
                                     (chezmoi-find (expand-file-name fn (getenv "HOME")))))
```

Which allows org-mode links like: `[[dotfile:.profile][.profile]]` to jump to the target state.

Admittedly, I don't have a concrete use case for the change to `chezmoi-ediff`, but it might be useful to someone at some point.