### PR TITLE
Fix dependency header

### DIFF
--- a/chezmoi-company.el
+++ b/chezmoi-company.el
@@ -3,7 +3,6 @@
 ;; Author: Harrison Pielke-Lombardo
 ;; Maintainer: Harrison Pielke-Lombardo
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "27.1"))
 ;; Homepage: http://www.github.com/tuh8888/chezmoi.el
 ;; Keywords: vc
 

--- a/chezmoi-ediff.el
+++ b/chezmoi-ediff.el
@@ -3,7 +3,6 @@
 ;; Author: Harrison Pielke-Lombardo
 ;; Maintainer: Harrison Pielke-Lombardo
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1"))
 ;; Homepage: http://www.github.com/tuh8888/chezmoi.el
 ;; Keywords: vc
 

--- a/chezmoi-magit.el
+++ b/chezmoi-magit.el
@@ -3,7 +3,6 @@
 ;; Author: Harrison Pielke-Lombardo
 ;; Maintainer: Harrison Pielke-Lombardo
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1") (magit "3.0.0"))
 ;; Homepage: http://www.github.com/tuh8888/chezmoi.el
 ;; Keywords: vc
 

--- a/chezmoi-template.el
+++ b/chezmoi-template.el
@@ -3,7 +3,6 @@
 ;; Author: Harrison Pielke-Lombardo
 ;; Maintainer: Harrison Pielke-Lombardo
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1"))
 ;; Homepage: http://www.github.com/tuh8888/chezmoi.el
 ;; Keywords: vc
 

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -3,7 +3,7 @@
 ;; Author: Harrison Pielke-Lombardo
 ;; Maintainer: Harrison Pielke-Lombardo
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "26.1") (magit "3.0.0") (company "0.9.13"))
 ;; Homepage: http://www.github.com/tuh8888/chezmoi.el
 ;; Keywords: vc
 


### PR DESCRIPTION
- It should be put only in main file
- Add company to the dependency header

I got following errors when I installed this package.

```
Entering directory ‘/home/syohei/.emacs.d/elpa/chezmoi-20220310.2014/’
chezmoi-company.el:33:2: Error: Cannot open load file: No such file or directory, company

Compiling file /home/syohei/.emacs.d/elpa/chezmoi-20220310.2014/chezmoi-magit.el at Mon Jul 11 17:38:48 2022
chezmoi-magit.el:33:2: Error: Cannot open load file: No such file or directory, magit

Compiling file /home/syohei/.emacs.d/elpa/chezmoi-20220310.2014/chezmoi.el at Mon Jul 11 17:38:48 2022
chezmoi.el:41:2: Error: Cannot open load file: No such file or directory, magit
```