### PR TITLE
Fix `chezmoi diff`, optimize changed files

### DIFF
--- a/chezmoi-core.el
+++ b/chezmoi-core.el
@@ -45,6 +45,11 @@
   :type '(string)
   :group 'chezmoi)
 
+(defcustom chezmoi-use-template-source-mode-regex '(".*")
+  "If any match, activates the target file major mode in template files."
+  :group 'chezmoi
+  :type '(repeat string))
+
 (defvar chezmoi-command-error-regex "chezmoi:"
   "Regex for detecting if chezmoi has encountered an error.")
 

--- a/chezmoi-core.el
+++ b/chezmoi-core.el
@@ -56,6 +56,12 @@ If the target has been changed, it will be overwritten."
   :group 'chezmoi
   :type '(boolean))
 
+(defcustom chezmoi-root (file-name-as-directory
+             (substring (shell-command-to-string "chezmoi source-path") 0 -1))
+"The source directory for chezmoi."
+  :group 'chezmoi
+  :type '(string))
+
 (defvar chezmoi-command-error-regex "chezmoi:"
   "Regex for detecting if chezmoi has encountered an error.")
 
@@ -83,6 +89,13 @@ If the target has been changed, it will be overwritten."
   '(".literal"
     ".tmpl")
   "Source state attribute suffixes.")
+
+(defun chezmoi--mode-from-path ()
+  "Activate `chezmoi-mode' in source files based on their path"
+  (when (string-match chezmoi-root (buffer-file-name))
+    (unless chezmoi-mode (chezmoi-mode))))
+
+(add-hook 'find-file-hook #'chezmoi--mode-from-path)
 
 (provide 'chezmoi-core)
 

--- a/chezmoi-core.el
+++ b/chezmoi-core.el
@@ -50,6 +50,12 @@
   :group 'chezmoi
   :type '(repeat string))
 
+(defcustom chezmoi-mode-overwrite-destination nil
+  "Always attach a hook to write to the target file to chezmoi buffers.
+If the target has been changed, it will be overwritten."
+  :group 'chezmoi
+  :type '(boolean))
+
 (defvar chezmoi-command-error-regex "chezmoi:"
   "Regex for detecting if chezmoi has encountered an error.")
 

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -90,6 +90,32 @@ If ARG is non-nil, switch to the diff-buffer."
       (whitespace-mode 0))
     b))
 
+(defvar chezmoi--merge-procs nil "List of chezmoi merge processes.")
+
+(defun chezmoi-merge (file)
+  "Runs chezmoi merge on `FILE'.
+Requires chezmoi to be configured with an external mergetool (emacs, perhaps?)."
+  (interactive
+   (list (chezmoi--completing-read "Select a dotfile to merge: "
+                   (chezmoi-changed-files)
+                   'project-file)))
+  (when (file-exists-p file)
+    (push (start-process-shell-command "chezmoi" nil (concat "chezmoi merge " file))
+          chezmoi--merge-procs)))
+
+(defun chezmoi-merge-all ()
+  "Call 'chezmoi merge-all'."
+  (interactive)
+  (push (start-process-shell-command "chezmoi" nil "chezmoi merge-all")
+        chezmoi--merge-procs))
+
+(defun chezmoi-merge-quit ()
+  "Help, I ran chezmoi merge without reading the documentation!"
+  (interactive)
+  (dolist (i chezmoi--merge-procs)
+    (kill-process i))
+  (setq chezmoi--merge-procs nil))
+
 (defun chezmoi-changed-files ()
   "Use chezmoi status to return the files that have changed."
   (let ((files '()))

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -76,6 +76,23 @@
 	       (cl-mapcar #'expand-file-name)
 	       (member (expand-file-name file))))
 
+(defun chezmoi-source-file-p (file)
+  "Returns non-nil if `FILE' is in the source state."
+  (string-match chezmoi-root file))
+
+(defun chezmoi-encrypted-p (file)
+  "Returns non-nil if `FILE' is encrypted in the source state."
+  (or (string-match "encrypted_" file)
+      (string-match "encrypted_" (or (chezmoi-source-file file) ""))))
+
+(defun chezmoi-template-file-p (file)
+  "Returns non-nil if `FILE' is a chezmoi template file.
+
+Does not check if the file is managed by chezmoi."
+  (string-match ".*\\.tmpl" (if (chezmoi-source-file-p file)
+                                file
+                              (chezmoi-source-file file))))
+
 (defun chezmoi-diff (arg)
   "View output of =chezmoi diff= in a diff-buffer.
 If ARG is non-nil, switch to the diff-buffer."
@@ -332,9 +349,7 @@ Prefix ARG is passed to `chezmoi-write'."
   (interactive (list (buffer-file-name)))
   (if (chezmoi-target-file-p file)
       (chezmoi-find file)
-    (thread-first file
-		  chezmoi-target-file
-		  find-file)))
+    (find-file (chezmoi-target-file file))))
 
 (defun chezmoi-font-lock-keywords ()
   "Keywords for font lock."

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -94,12 +94,11 @@ If ARG is non-nil, switch to the diff-buffer."
   "Use chezmoi status to return the files that have changed."
   (let ((files '()))
     (with-temp-buffer
-      ;; note, can use "-p absolute" to get the full path directly
-      (call-process-shell-command "chezmoi status" nil (current-buffer))
-      (while(re-search-backward "^[[:space:]|ADMR][ADMR] \\(.*\\)" nil t)
-        (let ((match (match-string 1)))
-                (when match (push (concat "~/" match) files))))
-      files))
+
+    (call-process-shell-command "chezmoi status" nil (current-buffer))
+    (while (re-search-backward "^[[:space:]|ADMR][ADMR] \\(.*\\)" nil t)
+              (push (concat "~/" (match-string 1)) files))
+      files)))
 
 (defun chezmoi-changed-p (file)
   "Return non-nil of FILE has changed."

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -94,10 +94,11 @@ If ARG is non-nil, switch to the diff-buffer."
   "Use chezmoi status to return the files that have changed."
   (let ((files '()))
     (with-temp-buffer
+      ;; note, can use "-p absolute" to get the full path directly
       (call-process-shell-command "chezmoi status" nil (current-buffer))
-      (re-search-backward "[[:space:]]*[^[:space:]] \\(.*\\)" nil t)
+      (re-search-backward "^[[:space:]|ADMR][ADMR] \\(.*\\)" nil t)
       (let ((match (match-string 1)))
-        (when match (push match files)))
+        (when match (push (concat "~/" match) files)))
       files)))
 
 (defun chezmoi-changed-p (file)

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -261,10 +261,8 @@ Note: Does not run =chezmoi edit=."
   (let ((source-file (chezmoi-source-file file)))
     (when source-file
       (find-file source-file)
-      (let ((target-file (chezmoi-target-file source-file)))
-	(when-let ((mode (thread-first target-file
-				       file-name-nondirectory
-				       (assoc-default auto-mode-alist 'string-match))))
+      (let ((target-file (expand-file-name file)))
+	(when-let ((mode (assoc-default target-file auto-mode-alist 'string-match))))
           (funcall
            (if (and (listp mode) (null (car mode)))
                (save-window-excursion

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -91,15 +91,13 @@ If ARG is non-nil, switch to the diff-buffer."
     b))
 
 (defun chezmoi-changed-files ()
-  "Use chezmoi diff to return the files that have changed."
-  (with-current-buffer (chezmoi-diff t)
-    (goto-char (point-max))
-    (let (files line-beg)
-      (while (setq line-beg (re-search-backward "^\\+\\{3\\} .*" nil t))
-	(let ((file-name (thread-first line-beg
-				       (buffer-substring-no-properties (line-end-position))
-				       (substring 5))))
-	  (push (concat "~" file-name) files)))
+  "Use chezmoi status to return the files that have changed."
+  (let ((files '()))
+    (with-temp-buffer
+      (call-process-shell-command "chezmoi status" nil (current-buffer))
+      (re-search-backward "[[:space:]]*[^[:space:]] \\(.*\\)" nil t)
+      (let ((match (match-string 1)))
+        (when match (push match files)))
       files)))
 
 (defun chezmoi-changed-p (file)

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -248,6 +248,12 @@ PROMPT, CHOICES, and CATEGORY are passed to `complete-with-action'."
 		       (complete-with-action action choices string predicate)))
 		   nil t))
 
+(defun chezmoi--use-template (file)
+  "If the input `FILE' matches the regex."
+  (let ((ret))
+        (dolist (i chezmoi-use-template-source-mode-regex ret)
+        (setq ret (or ret (string-match i file))))))
+
 (defun chezmoi-find (file)
   "Edit a source FILE managed by chezmoi.
 If the target file has the same state as the source file,add a hook to
@@ -262,7 +268,8 @@ Note: Does not run =chezmoi edit=."
     (when source-file
       (find-file source-file)
       (let ((target-file (expand-file-name file)))
-	(when-let ((mode (assoc-default target-file auto-mode-alist 'string-match))))
+	(when-let ((mode (and (chezmoi--use-template target-file)
+                              (assoc-default target-file auto-mode-alist 'string-match))))
           (funcall
            (if (and (listp mode) (null (car mode)))
                (save-window-excursion

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -343,9 +343,10 @@ Prefix ARG is passed to `chezmoi-write'."
 (define-minor-mode chezmoi-mode
   "Chezmoi mode for source files."
   :group 'chezmoi
+  (defvar chezmoi-mode-overwrite-destination) ; silence
   (if chezmoi-mode
       (progn
-	(unless (chezmoi-changed-p (buffer-file-name))
+	(when (or chezmoi-mode-overwrite-destination (chezmoi-changed-p (buffer-file-name)))
 	  (add-hook 'after-save-hook #'chezmoi-write 0 t))
 	(add-hook 'after-change-functions #'chezmoi-template--after-change nil 1)
 

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -96,10 +96,10 @@ If ARG is non-nil, switch to the diff-buffer."
     (with-temp-buffer
       ;; note, can use "-p absolute" to get the full path directly
       (call-process-shell-command "chezmoi status" nil (current-buffer))
-      (re-search-backward "^[[:space:]|ADMR][ADMR] \\(.*\\)" nil t)
-      (let ((match (match-string 1)))
-        (when match (push (concat "~/" match) files)))
-      files)))
+      (while(re-search-backward "^[[:space:]|ADMR][ADMR] \\(.*\\)" nil t)
+        (let ((match (match-string 1)))
+                (when match (push (concat "~/" match) files))))
+      files))
 
 (defun chezmoi-changed-p (file)
   "Return non-nil of FILE has changed."

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -83,7 +83,7 @@ If ARG is non-nil, switch to the diff-buffer."
   (let ((b (get-buffer-create "*chezmoi-diff*")))
     (with-current-buffer b
       (erase-buffer)
-      (chezmoi--locally (shell-command (concat chezmoi-command " diff") b)))
+      (chezmoi--locally (shell-command (concat chezmoi-command " diff --use-builtin-diff") b)))
     (unless arg
       (switch-to-buffer b)
       (diff-mode)

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -265,10 +265,18 @@ Note: Does not run =chezmoi edit=."
 	(when-let ((mode (thread-first target-file
 				       file-name-nondirectory
 				       (assoc-default auto-mode-alist 'string-match))))
-	  (funcall mode))
-	(message target-file)
-	(unless chezmoi-mode (chezmoi-mode))
-	source-file))))
+          (funcall
+           (if (and (listp mode) (null (car mode)))
+               (save-window-excursion
+                 (let* ((existed (get-file-buffer target-file))
+                        (_ (find-file target-file))
+                        (m major-mode))
+                   (unless existed (kill-current-buffer))
+                   m))
+	     mode)))
+        (message target-file)
+        (unless chezmoi-mode (chezmoi-mode))
+        source-file))))
 
 (defun chezmoi-sync-files (files &optional arg)
   "Iteratively select file from FILES to sync.

--- a/chezmoi.el
+++ b/chezmoi.el
@@ -93,6 +93,7 @@ Does not check if the file is managed by chezmoi."
                                 file
                               (chezmoi-source-file file))))
 
+;;;###autoload
 (defun chezmoi-diff (arg)
   "View output of =chezmoi diff= in a diff-buffer.
 If ARG is non-nil, switch to the diff-buffer."
@@ -109,6 +110,7 @@ If ARG is non-nil, switch to the diff-buffer."
 
 (defvar chezmoi--merge-procs nil "List of chezmoi merge processes.")
 
+;;;###autoload
 (defun chezmoi-merge (file)
   "Runs chezmoi merge on `FILE'.
 Requires chezmoi to be configured with an external mergetool (emacs, perhaps?)."
@@ -120,6 +122,7 @@ Requires chezmoi to be configured with an external mergetool (emacs, perhaps?)."
     (push (start-process-shell-command "chezmoi" nil (concat "chezmoi merge " file))
           chezmoi--merge-procs)))
 
+;;;###autoload
 (defun chezmoi-merge-all ()
   "Call 'chezmoi merge-all'."
   (interactive)
@@ -241,6 +244,7 @@ Requires chezmoi to be configured with an external mergetool (emacs, perhaps?)."
 		 chezmoi--dispatch
 		 cl-first)))
 
+;;;###autoload
 (defun chezmoi-write (&optional file arg)
   "Sync FILE.  How it syncs depends if FILE is in source or target.
 If FILE is in source state, run =chezmoi apply= on the target to overwrite it.
@@ -296,6 +300,7 @@ PROMPT, CHOICES, and CATEGORY are passed to `complete-with-action'."
         (dolist (i chezmoi-use-template-source-mode-regex ret)
         (setq ret (or ret (string-match i file))))))
 
+;;;###autoload
 (defun chezmoi-find (file)
   "Edit a source FILE managed by chezmoi.
 If the target file has the same state as the source file,add a hook to
@@ -325,6 +330,7 @@ Note: Does not run =chezmoi edit=."
         (unless chezmoi-mode (chezmoi-mode))
         source-file))))
 
+;;;###autoload
 (defun chezmoi-sync-files (files &optional arg)
   "Iteratively select file from FILES to sync.
 Interactively select whether to sync the source state or the target state.
@@ -344,6 +350,7 @@ Prefix ARG is passed to `chezmoi-write'."
 		(chezmoi-write file arg))
       (setq files (remove file files)))))
 
+;;;###autoload
 (defun chezmoi-open-other (file)
   "Open buffer's target FILE."
   (interactive (list (buffer-file-name)))
@@ -355,6 +362,7 @@ Prefix ARG is passed to `chezmoi-write'."
   "Keywords for font lock."
   `((,chezmoi-template-regex 0 'chezmoi-template-face prepend)))
 
+;;;###autoload
 (define-minor-mode chezmoi-mode
   "Chezmoi mode for source files."
   :group 'chezmoi

--- a/extensions/chezmoi-dired.el
+++ b/extensions/chezmoi-dired.el
@@ -33,6 +33,7 @@
 (require 'dired)
 (require 'chezmoi)
 
+;;;###autoload
 (defun chezmoi-dired-add-marked-files ()
   "Add files marked in Dired to source state."
   (interactive)

--- a/extensions/chezmoi-ediff.el
+++ b/extensions/chezmoi-ediff.el
@@ -38,6 +38,13 @@
   :type '(boolean)
   :group 'chezmoi)
 
+(defcustom chezmoi-ediff-template-use-ediff3 t
+  "If `chezmoi-ediff' between template files should .
+This creates false diffs for every template element, but allows easily
+changing the source template file."
+  :type '(boolean)
+  :group 'chezmoi)
+
 (defvar-local chezmoi-ediff--source-file nil
   "Current ediff source-file.")
 
@@ -66,24 +73,81 @@ N, BUF-TYPE, CTRL-BUF, START, and END are all passed to `ediff'."
 (defvar chezmoi-ediff--ediff-quit-hook ()
   (advice-remove 'ediff-get-region-contents #'chezmoi-ediff--ediff-get-region-contents))
 
+(defun chezmoi--get-ancestor (source-file)
+  "Create a tempf file for the source file at git HEAD ."
+  (let* ((relative (substring source-file (length chezmoi-root)))
+         (rev (substring (shell-command-to-string "git rev-parse --short HEAD") 0 -1))
+         (temp-name (expand-file-name relative (expand-file-name rev temporary-file-directory))))
+    (make-directory (file-name-directory temp-name) t)
+    (with-temp-file temp-name
+      (shell-command (concat "git show " (shell-quote-argument (concat rev ":" relative)))
+                     (current-buffer)))
+    temp-name))
+
+(defun chezmoi-ediff-merge (file)
+  "Start an `ediff-merge-with-ancestor' session of `FILE'.
+Merge source, target, and ancestor.
+
+Note: Does not run =chezmoi merge=."
+  (interactive (list (buffer-file-name)))
+  (let* ((target (chezmoi-target-file-p file))
+         (sourcef (if target
+                    (chezmoi-source-file file)
+                  file))
+        (targetf (if target
+                     file
+                   (chezmoi-target-file file))))
+    (unless (and sourcef targetf)
+      (user-error "Error finding source and target files."))
+    (ediff-merge-buffers-with-ancestor
+     (if (chezmoi-template-file-p sourcef)
+         (chezmoi-template--buffer sourcef)
+       (find-file sourcef))
+     (find-file-noselect targetf)
+     (find-file-noselect (chezmoi--get-ancestor sourcef)))))
+
+(defun chezmoi-template--buffer (template-file)
+  "Execute template from `TEMPLATE-FILE' and insert into a new buffer.
+Return the new buffer."
+  (unless (chezmoi-template-file-p template-file)
+    (error "File: %s is not a chezmoi template file" template-file))
+  (let ((buf (get-buffer-create (make-temp-name template-file))))
+        (shell-command (format "%s execute-template %s"
+                       chezmoi-command
+                       (shell-quote-argument
+                        (with-temp-buffer (insert-file-contents template-file) (buffer-string))))
+               buf)
+        buf))
+
 (defun chezmoi-ediff (file)
   "Choose a FILE to merge with its source using `ediff'.
+If the current file is in `chezmoi-mode', diff the current file.
+Otherwise, or if used with a prefix arg, choose from all chezmoi
+managed files.
+
 Note: Does not run =chezmoi merge=."
   (interactive
-   (list (chezmoi--completing-read "Select a dotfile to merge: "
+   (list (if (and chezmoi-mode (not current-prefix-arg))
+             (chezmoi-target-file (buffer-file-name))
+           (chezmoi--completing-read "Select a dotfile to merge: "
 				   (chezmoi-changed-files)
-				   'project-file)))
-  (let* ((ident (when (fboundp 'chezmoi-age-get-identity) (chezmoi-age-get-identity)))
-	 (recips (when (fboundp 'chezmoi-age-get-recipients) (chezmoi-age-get-recipients)))
-	 (age-always-use-default-keys (and (equal ident age-default-identity)
-					   (equal (if (equal 1 (length recips))
-						      (car recips)
-						    recips)
-						  age-default-recipient))))
-    (let* ((source-file (chezmoi-find file)))
+				   'project-file))))
+  (let* ((source-file (chezmoi-find file)))
+      (if (and chezmoi-ediff-template-use-ediff3
+               (not (chezmoi-encrypted-p source-file))
+               (chezmoi-template-file-p source-file))
+          (progn (let ((temp (make-temp-file (file-name-nondirectory file))))
+                   (with-temp-file temp
+                     (shell-command (format "%s execute-template %s"
+                                            chezmoi-command
+                                            (shell-quote-argument
+                                             (with-temp-buffer (insert-file-contents source-file) (buffer-string))))
+                                    (current-buffer)))
+                (ediff3 temp file source-file)))
       (advice-add 'ediff-get-region-contents :override #'chezmoi-ediff--ediff-get-region-contents)
       (setq chezmoi-ediff--source-file source-file)
-      (ediff-files source-file file)
+      (ediff source-file file)
+      ;; (ediff-merge-files-with-ancestor source-file file (chezmoi--get-ancestor source-file) nil file)
       (add-hook 'ediff-cleanup-hook #'chezmoi-ediff--ediff-cleanup-hook nil t)
       (add-hook 'ediff-quit-hook #'chezmoi-ediff--ediff-quit-hook nil t))))
 

--- a/extensions/chezmoi-ediff.el
+++ b/extensions/chezmoi-ediff.el
@@ -74,7 +74,7 @@ N, BUF-TYPE, CTRL-BUF, START, and END are all passed to `ediff'."
   (advice-remove 'ediff-get-region-contents #'chezmoi-ediff--ediff-get-region-contents))
 
 (defun chezmoi--get-ancestor (source-file)
-  "Create a tempf file for the source file at git HEAD ."
+  "Create a temp file for the source file at git HEAD ."
   (let* ((relative (substring source-file (length chezmoi-root)))
          (rev (substring (shell-command-to-string "git rev-parse --short HEAD") 0 -1))
          (temp-name (expand-file-name relative (expand-file-name rev temporary-file-directory))))
@@ -84,6 +84,7 @@ N, BUF-TYPE, CTRL-BUF, START, and END are all passed to `ediff'."
                      (current-buffer)))
     temp-name))
 
+;;;###autoload
 (defun chezmoi-ediff-merge (file)
   "Start an `ediff-merge-with-ancestor' session of `FILE'.
 Merge source, target, and ancestor.
@@ -119,6 +120,7 @@ Return the new buffer."
                buf)
         buf))
 
+;;;###autoload
 (defun chezmoi-ediff (file)
   "Choose a FILE to merge with its source using `ediff'.
 If the current file is in `chezmoi-mode', diff the current file.

--- a/extensions/chezmoi-magit.el
+++ b/extensions/chezmoi-magit.el
@@ -33,6 +33,7 @@
 (require 'chezmoi)
 (require 'magit)
 
+;;;###autoload
 (defun chezmoi-magit-status ()
   "Show the status of the chezmoi source repository."
   (interactive)


### PR DESCRIPTION
## Issue
I have chezmoi's diff tool set to use emacs and `chezmoi-find` did not complete since it appeared to expect the raw output from chezmoi's default.

## Fixes/Additions
- Add "--use-builtin-diff" to `chezmoi-diff` shell command to force the default output expected by other functions
- Edit `chezmoi-changed-files` to use `chezmoi status` instead of `chezmoi diff` since it is much faster